### PR TITLE
 autoscalerRef is not optional

### DIFF
--- a/docs/gitbook/how-it-works.md
+++ b/docs/gitbook/how-it-works.md
@@ -23,7 +23,7 @@ spec:
   # the maximum time in seconds for the canary deployment
   # to make progress before it is rollback (default 600s)
   progressDeadlineSeconds: 60
-  # HPA reference (optional)
+  # HPA reference
   autoscalerRef:
     apiVersion: autoscaling/v2beta1
     kind: HorizontalPodAutoscaler

--- a/docs/gitbook/usage/progressive-delivery.md
+++ b/docs/gitbook/usage/progressive-delivery.md
@@ -34,7 +34,7 @@ spec:
   # the maximum time in seconds for the canary deployment
   # to make progress before it is rollback (default 600s)
   progressDeadlineSeconds: 60
-  # HPA reference (optional)
+  # HPA reference
   autoscalerRef:
     apiVersion: autoscaling/v2beta1
     kind: HorizontalPodAutoscaler

--- a/pkg/controller/deployer.go
+++ b/pkg/controller/deployer.go
@@ -192,7 +192,7 @@ func (c *CanaryDeployer) SyncStatus(cd *flaggerv1.Canary, status flaggerv1.Canar
 	cd.Status.FailedChecks = status.FailedChecks
 	cd.Status.CanaryRevision = specEnc
 	cd.Status.LastTransitionTime = metav1.Now()
-	cd, err = c.flaggerClient.FlaggerV1alpha2().Canaries(cd.Namespace).Update(cd)
+	_, err = c.flaggerClient.FlaggerV1alpha2().Canaries(cd.Namespace).Update(cd)
 	if err != nil {
 		return fmt.Errorf("deployment %s.%s update error %v", cd.Spec.TargetRef.Name, cd.Namespace, err)
 	}


### PR DESCRIPTION
        deployment jx-staging-croc-hunter-jenkinsx.jx-staging update error Canary.flagger.app \"jx-staging-croc-hunter-jenkinsx\" is invalid: []: Invalid value:
        ...
        validation failure list:\nspec.autoscalerRef.apiVersion in body is required","stacktrace":"github.com/stefanprodan/flagger/pkg/controller.(*Controller).checkCanaryStatus\n\t/go/src/github.com/stefanprodan/flagger/pkg/controller/scheduler.go:217\ngithub.com/stefanprodan/flagger/pkg/controller.(*Controller).advanceCanary\n\t/go/src/github.com/stefanprodan/flagger/pkg/controller/scheduler.go:76"}

Should it be optional? What is the hpa needed for?


Fix bad error message

    "controller/scheduler.go:217","msg":"deployment . update error Canary.flagger.app \"jx-staging-croc-hunter-jenkinsx\" is invalid: []: Invalid value: map[string]interface {}{\"metadata\":map[string]interface {}{\"name\":\"jx-staging-croc-hunter-jenkinsx\", \"namespace\":\"jx-staging\", \"selfLink\":\"/apis/flagger.app/v1alpha2/namespaces/jx-staging/canaries/jx-staging-croc-hunter-jenkinsx\", \"uid\":\"b248877e-1406-11e9-bf64-42010a8000c6\", \"resourceVersion\":\"30650895\", \"generation\":1, \"creationTimestamp\":\"2019-01-09T12:04:20Z\"}, \"spec\":map[string]interface {}{\"canaryAnalysis\":map[string]interface {}{\"threshold\":5, \"maxWeight\":50, \"stepWeight\":10, \"metrics\":[]interface {}{map[string]interface {}{\"name\":\"istio_requests_total\", \"interval\":\"1m\", \"threshold\":99}, map[string]interface {}{\"name\":\"istio_request_duration_seconds_bucket\", \"interval\":\"30s\"istio-system/flagger-b486d78c8-fkmbr[flagger]: {"level":"info","ts":"2019-01-09T12:14:05.158Z","caller":"controller/deployer.go:228","msg":"Scaling down jx-staging-croc-hunter-jenkinsx.jx-staging"}
