### PR TITLE
Wrong VirtualService routes

### DIFF
--- a/pkg/controller/router.go
+++ b/pkg/controller/router.go
@@ -164,7 +164,7 @@ func (c *CanaryRouter) createServices(cd *flaggerv1.Canary) error {
 }
 
 func (c *CanaryRouter) createVirtualService(cd *flaggerv1.Canary) error {
-	canaryName := cd.Name
+	canaryName := cd.Spec.TargetRef.Name
 	primaryName := fmt.Sprintf("%s-primary", canaryName)
 	hosts := append(cd.Spec.Service.Hosts, canaryName)
 	gateways := append(cd.Spec.Service.Gateways, "mesh")


### PR DESCRIPTION
If deployment name is different from canary name
the virtual service routes are created with canary name
but the services are created with deployment name

Note that canary name should match deployment name