### PR TITLE
Use Kubernetes 1.11 CRD status sub-resource 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 Flagger is a Kubernetes operator that automates the promotion of canary deployments
 using Istio routing for traffic shifting and Prometheus metrics for canary analysis. 
-The canary analysis can be extended with webhooks for running integration tests, load tests or any other custom 
-validation.
+The canary analysis can be extended with webhooks for running integration tests, 
+load tests or any other custom validation.
 
 ### Install 
 
@@ -28,7 +28,7 @@ helm upgrade -i flagger flagger/flagger \
 --set metricsServer=http://prometheus.istio-system:9090 
 ```
 
-Flagger is compatible with Kubernetes >1.10.0 and Istio >1.0.0.
+Flagger is compatible with Kubernetes >1.11.0 and Istio >1.0.0.
 
 ### Usage
 

--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -20,6 +20,15 @@ spec:
     singular: canary
     kind: Canary
   scope: Namespaced
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+    - name: Status
+      type: string
+      JSONPath: .status.state
+    - name: LastTransitionTime
+      type: string
+      JSONPath: .status.lastTransitionTime
   validation:
     openAPIV3Schema:
       properties:

--- a/charts/flagger/Chart.yaml
+++ b/charts/flagger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: flagger
-version: 0.3.0
+version: 0.4.0
 appVersion: 0.3.1-alpha.1
-kubeVersion: ">=1.9.0-0"
+kubeVersion: ">=1.11.0-0"
 engine: gotpl
 description: Flagger is a Kubernetes operator that automates the promotion of canary deployments using Istio routing for traffic shifting and Prometheus metrics for canary analysis.
 home: https://docs.flagger.app

--- a/charts/flagger/README.md
+++ b/charts/flagger/README.md
@@ -8,7 +8,7 @@ Based on the KPIs analysis a canary is promoted or aborted and the analysis resu
 
 ## Prerequisites
 
-* Kubernetes >= 1.9
+* Kubernetes >= 1.11
 * Istio >= 1.0
 * Prometheus >= 2.6
 

--- a/charts/flagger/templates/crd.yaml
+++ b/charts/flagger/templates/crd.yaml
@@ -21,6 +21,15 @@ spec:
     singular: canary
     kind: Canary
   scope: Namespaced
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+    - name: Status
+      type: string
+      JSONPath: .status.state
+    - name: LastTransitionTime
+      type: string
+      JSONPath: .status.lastTransitionTime
   validation:
     openAPIV3Schema:
       properties:

--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -4,13 +4,20 @@ description: Flagger is an Istio progressive delivery Kubernetes operator
 
 # Introduction
 
-[Flagger](https://github.com/stefanprodan/flagger) is a **Kubernetes** operator that automates the promotion of canary deployments using **Istio** routing for traffic shifting and **Prometheus** metrics for canary analysis.
+[Flagger](https://github.com/stefanprodan/flagger) is a **Kubernetes** operator that automates the promotion of canary 
+deployments using **Istio** routing for traffic shifting and **Prometheus** metrics for canary analysis.
+The canary analysis can be extended with webhooks for running integration tests, 
+load tests or any other custom validation.
 
-Flagger implements a control loop that gradually shifts traffic to the canary while measuring key performance indicators like HTTP requests success rate, requests average duration and pods health. Based on the **KPIs** analysis a canary is promoted or aborted and the analysis result is published to **Slack**.
+Flagger implements a control loop that gradually shifts traffic to the canary while measuring key performance 
+indicators like HTTP requests success rate, requests average duration and pods health. 
+Based on the **KPIs** analysis a canary is promoted or aborted and the analysis result is published to **Slack**.
 
 ![Flagger overview diagram](https://raw.githubusercontent.com/stefanprodan/flagger/master/docs/diagrams/flagger-canary-overview.png)
 
-Flagger can be configured with Kubernetes custom resources \(canaries.flagger.app kind\) and is compatible with any CI/CD solutions made for Kubernetes. Since Flagger is declarative and reacts to Kubernetes events, it can be used in **GitOps** pipelines together with Weave Flux or JenkinsX.
+Flagger can be configured with Kubernetes custom resources \(canaries.flagger.app kind\) and is compatible with 
+any CI/CD solutions made for Kubernetes. Since Flagger is declarative and reacts to Kubernetes events, 
+it can be used in **GitOps** pipelines together with Weave Flux or JenkinsX.
 
 This project is sponsored by [Weaveworks](https://www.weave.works/)
 

--- a/docs/gitbook/install/install-flagger.md
+++ b/docs/gitbook/install/install-flagger.md
@@ -6,7 +6,7 @@ If you are new to Istio you can follow this GKE guide
 
 **Prerequisites**
 
-* Kubernetes &gt;= 1.9
+* Kubernetes &gt;= 1.11
 * Istio &gt;= 1.0
 * Prometheus &gt;= 2.6
 

--- a/pkg/controller/deployer.go
+++ b/pkg/controller/deployer.go
@@ -140,7 +140,7 @@ func (c *CanaryDeployer) IsNewSpec(cd *flaggerv1.Canary) (bool, error) {
 	newSpec := &canary.Spec.Template.Spec
 	oldSpecJson, err := base64.StdEncoding.DecodeString(cd.Status.CanaryRevision)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("%s.%s decode error %v", cd.Name, cd.Namespace, err)
 	}
 	oldSpec := &corev1.PodSpec{}
 	err = json.Unmarshal(oldSpecJson, oldSpec)
@@ -154,6 +154,14 @@ func (c *CanaryDeployer) IsNewSpec(cd *flaggerv1.Canary) (bool, error) {
 	}
 
 	return false, nil
+}
+
+// ShouldAdvance determines if the canary analysis can proceed
+func (c *CanaryDeployer) ShouldAdvance(cd *flaggerv1.Canary) (bool, error) {
+	if cd.Status.CanaryRevision == "" || cd.Status.State == flaggerv1.CanaryRunning {
+		return true, nil
+	}
+	return c.IsNewSpec(cd)
 }
 
 // SetFailedChecks updates the canary failed checks counter

--- a/pkg/controller/deployer.go
+++ b/pkg/controller/deployer.go
@@ -162,7 +162,7 @@ func (c *CanaryDeployer) SetFailedChecks(cd *flaggerv1.Canary, val int) error {
 	cdCopy.Status.FailedChecks = val
 	cdCopy.Status.LastTransitionTime = metav1.Now()
 
-	cd, err := c.flaggerClient.FlaggerV1alpha3().Canaries(cd.Namespace).Update(cdCopy)
+	cd, err := c.flaggerClient.FlaggerV1alpha3().Canaries(cd.Namespace).UpdateStatus(cdCopy)
 	if err != nil {
 		return fmt.Errorf("canary %s.%s status update error %v", cdCopy.Name, cdCopy.Namespace, err)
 	}
@@ -175,7 +175,7 @@ func (c *CanaryDeployer) SetState(cd *flaggerv1.Canary, state flaggerv1.CanarySt
 	cdCopy.Status.State = state
 	cdCopy.Status.LastTransitionTime = metav1.Now()
 
-	cd, err := c.flaggerClient.FlaggerV1alpha3().Canaries(cd.Namespace).Update(cdCopy)
+	cd, err := c.flaggerClient.FlaggerV1alpha3().Canaries(cd.Namespace).UpdateStatus(cdCopy)
 	if err != nil {
 		return fmt.Errorf("canary %s.%s status update error %v", cdCopy.Name, cdCopy.Namespace, err)
 	}
@@ -203,7 +203,7 @@ func (c *CanaryDeployer) SyncStatus(cd *flaggerv1.Canary, status flaggerv1.Canar
 	cdCopy.Status.CanaryRevision = base64.StdEncoding.EncodeToString(specJson)
 	cdCopy.Status.LastTransitionTime = metav1.Now()
 
-	cd, err = c.flaggerClient.FlaggerV1alpha3().Canaries(cd.Namespace).Update(cdCopy)
+	cd, err = c.flaggerClient.FlaggerV1alpha3().Canaries(cd.Namespace).UpdateStatus(cdCopy)
 	if err != nil {
 		return fmt.Errorf("canary %s.%s status update error %v", cdCopy.Name, cdCopy.Namespace, err)
 	}

--- a/pkg/controller/router.go
+++ b/pkg/controller/router.go
@@ -276,13 +276,15 @@ func (c *CanaryRouter) SetRoutes(
 		}
 		return fmt.Errorf("VirtualService %s.%s query error %v", targetName, cd.Namespace, err)
 	}
-	vs.Spec.Http = []istiov1alpha3.HTTPRoute{
+
+	vsCopy := vs.DeepCopy()
+	vsCopy.Spec.Http = []istiov1alpha3.HTTPRoute{
 		{
 			Route: []istiov1alpha3.DestinationWeight{primary, canary},
 		},
 	}
 
-	vs, err = c.istioClient.NetworkingV1alpha3().VirtualServices(cd.Namespace).Update(vs)
+	vs, err = c.istioClient.NetworkingV1alpha3().VirtualServices(cd.Namespace).Update(vsCopy)
 	if err != nil {
 		return fmt.Errorf("VirtualService %s.%s update failed: %v", targetName, cd.Namespace, err)
 

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -91,6 +91,13 @@ func (c *Controller) advanceCanary(name string, namespace string) {
 		return
 	}
 
+	if ok, err := c.deployer.ShouldAdvance(cd); !ok {
+		if err != nil {
+			c.recordEventWarningf(cd, "%v", err)
+		}
+		return
+	}
+
 	// set max weight default value to 100%
 	maxWeight := 100
 	if cd.Spec.CanaryAnalysis.MaxWeight > 0 {
@@ -249,7 +256,7 @@ func (c *Controller) advanceCanary(name string, namespace string) {
 
 func (c *Controller) checkCanaryStatus(cd *flaggerv1.Canary, deployer CanaryDeployer) bool {
 	c.recorder.SetStatus(cd)
-	if cd.Status.State == "running" {
+	if cd.Status.State == flaggerv1.CanaryRunning {
 		return true
 	}
 


### PR DESCRIPTION
* drop compatibility with Kubernetes 1.10
* add status and additional printer columns to Canary CRD
* use CRD `UpdateStatus` for Canary status updates
* skip readiness checks if canary analysis finished