### PR TITLE
Refactor virtual service sync

### DIFF
--- a/pkg/controller/router.go
+++ b/pkg/controller/router.go
@@ -27,15 +27,14 @@ type CanaryRouter struct {
 	logger        *zap.SugaredLogger
 }
 
-// Sync creates the primary and canary ClusterIP services
-// and sets up a virtual service with routes for the two services
-// all traffic goes to primary
+// Sync creates or updates the primary and canary ClusterIP services
+// and the Istio virtual service.
 func (c *CanaryRouter) Sync(cd *flaggerv1.Canary) error {
 	err := c.createServices(cd)
 	if err != nil {
 		return err
 	}
-	err = c.createVirtualService(cd)
+	err = c.syncVirtualService(cd)
 	if err != nil {
 		return err
 	}
@@ -164,7 +163,7 @@ func (c *CanaryRouter) createServices(cd *flaggerv1.Canary) error {
 	return nil
 }
 
-func (c *CanaryRouter) createVirtualService(cd *flaggerv1.Canary) error {
+func (c *CanaryRouter) syncVirtualService(cd *flaggerv1.Canary) error {
 	targetName := cd.Spec.TargetRef.Name
 	primaryName := fmt.Sprintf("%s-primary", targetName)
 	hosts := append(cd.Spec.Service.Hosts, targetName)
@@ -199,8 +198,8 @@ func (c *CanaryRouter) createVirtualService(cd *flaggerv1.Canary) error {
 		},
 	}
 
+	// insert
 	if errors.IsNotFound(err) {
-		c.logger.Debugf("VirtualService %s.%s not found", targetName, cd.Namespace)
 		virtualService = &istiov1alpha3.VirtualService{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      targetName,
@@ -215,21 +214,33 @@ func (c *CanaryRouter) createVirtualService(cd *flaggerv1.Canary) error {
 			},
 			Spec: newSpec,
 		}
-		c.logger.Debugf("Creating VirtualService %s.%s", virtualService.GetName(), cd.Namespace)
 		_, err = c.istioClient.NetworkingV1alpha3().VirtualServices(cd.Namespace).Create(virtualService)
 		if err != nil {
 			return fmt.Errorf("VirtualService %s.%s create error %v", targetName, cd.Namespace, err)
 		}
-		c.logger.With("canary", fmt.Sprintf("%s.%s", cd.Name, cd.Namespace)).Infof("VirtualService %s.%s created", virtualService.GetName(), cd.Namespace)
-	} else if diff := cmp.Diff(newSpec, virtualService.Spec, cmpopts.IgnoreTypes(istiov1alpha3.DestinationWeight{})); diff != "" {
-		//fmt.Println(diff)
-		virtualService.Spec = newSpec
-		c.logger.Debugf("Updating VirtualService %s.%s", virtualService.GetName(), cd.Namespace)
-		_, err = c.istioClient.NetworkingV1alpha3().VirtualServices(cd.Namespace).Update(virtualService)
-		if err != nil {
-			return fmt.Errorf("VirtualService %s.%s update error %v", targetName, cd.Namespace, err)
+		c.logger.With("canary", fmt.Sprintf("%s.%s", cd.Name, cd.Namespace)).
+			Infof("VirtualService %s.%s created", virtualService.GetName(), cd.Namespace)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("VirtualService %s.%s query error %v", targetName, cd.Namespace, err)
+	}
+
+	// update service
+	if virtualService != nil {
+		if diff := cmp.Diff(newSpec, virtualService.Spec, cmpopts.IgnoreTypes(istiov1alpha3.DestinationWeight{})); diff != "" {
+			vtClone := virtualService.DeepCopy()
+			vtClone.Spec = newSpec
+			//TODO: keep original destination weights
+			//vtClone.Spec.Http = virtualService.Spec.Http
+			_, err = c.istioClient.NetworkingV1alpha3().VirtualServices(cd.Namespace).Update(vtClone)
+			if err != nil {
+				return fmt.Errorf("VirtualService %s.%s update error %v", targetName, cd.Namespace, err)
+			}
+			c.logger.With("canary", fmt.Sprintf("%s.%s", cd.Name, cd.Namespace)).
+				Infof("VirtualService %s.%s updated", virtualService.GetName(), cd.Namespace)
 		}
-		c.logger.With("canary", fmt.Sprintf("%s.%s", cd.Name, cd.Namespace)).Infof("VirtualService %s.%s updated", virtualService.GetName(), cd.Namespace)
 	}
 
 	return nil

--- a/pkg/controller/router.go
+++ b/pkg/controller/router.go
@@ -2,8 +2,8 @@ package controller
 
 import (
 	"fmt"
-	"reflect"
-
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	istiov1alpha3 "github.com/knative/pkg/apis/istio/v1alpha3"
 	istioclientset "github.com/knative/pkg/client/clientset/versioned"
 	flaggerv1 "github.com/stefanprodan/flagger/pkg/apis/flagger/v1alpha3"
@@ -221,7 +221,8 @@ func (c *CanaryRouter) createVirtualService(cd *flaggerv1.Canary) error {
 			return fmt.Errorf("VirtualService %s.%s create error %v", targetName, cd.Namespace, err)
 		}
 		c.logger.With("canary", fmt.Sprintf("%s.%s", cd.Name, cd.Namespace)).Infof("VirtualService %s.%s created", virtualService.GetName(), cd.Namespace)
-	} else if !reflect.DeepEqual(virtualService.Spec.Hosts, newSpec.Hosts) || !reflect.DeepEqual(virtualService.Spec.Gateways, newSpec.Gateways) {
+	} else if diff := cmp.Diff(newSpec, virtualService.Spec, cmpopts.IgnoreTypes(istiov1alpha3.DestinationWeight{})); diff != "" {
+		//fmt.Println(diff)
 		virtualService.Spec = newSpec
 		c.logger.Debugf("Updating VirtualService %s.%s", virtualService.GetName(), cd.Namespace)
 		_, err = c.istioClient.NetworkingV1alpha3().VirtualServices(cd.Namespace).Update(virtualService)


### PR DESCRIPTION
- detect changes in virtual service with `cmp`
- ignore destination weight when comparing the two specs
- add tests for virtual service insert, update and config drift

Followup of #51