### PR TITLE
 Add support for custom metrics

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -91,7 +91,7 @@ spec:
                   properties:
                     items:
                       type: object
-                      required: ['name', 'interval', 'threshold']
+                      required: ['name', 'threshold']
                       properties:
                         name:
                           type: string

--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -100,6 +100,8 @@ spec:
                           pattern: "^[0-9]+(m|s)"
                         threshold:
                           type: number
+                        query:
+                          type: string
                 webhooks:
                   type: array
                   properties:

--- a/charts/flagger/templates/crd.yaml
+++ b/charts/flagger/templates/crd.yaml
@@ -92,7 +92,7 @@ spec:
                   properties:
                     items:
                       type: object
-                      required: ['name', 'interval', 'threshold']
+                      required: ['name', 'threshold']
                       properties:
                         name:
                           type: string

--- a/charts/flagger/templates/crd.yaml
+++ b/charts/flagger/templates/crd.yaml
@@ -101,6 +101,8 @@ spec:
                           pattern: "^[0-9]+(m|s)"
                         threshold:
                           type: number
+                        query:
+                          type: string
                 webhooks:
                   type: array
                   properties:

--- a/pkg/apis/flagger/v1alpha3/types.go
+++ b/pkg/apis/flagger/v1alpha3/types.go
@@ -27,6 +27,7 @@ const (
 	CanaryKind              = "Canary"
 	ProgressDeadlineSeconds = 600
 	AnalysisInterval        = 60 * time.Second
+	MetricInterval          = "1m"
 )
 
 // +genclient
@@ -128,7 +129,7 @@ type CanaryAnalysis struct {
 // CanaryMetric holds the reference to Istio metrics used for canary analysis
 type CanaryMetric struct {
 	Name      string  `json:"name"`
-	Interval  string  `json:"interval"`
+	Interval  string  `json:"interval,omitempty"`
 	Threshold float64 `json:"threshold"`
 	// +optional
 	Query string `json:"query,omitempty"`
@@ -171,4 +172,9 @@ func (c *Canary) GetAnalysisInterval() time.Duration {
 	}
 
 	return interval
+}
+
+// GetMetricInterval returns the metric interval default value (1m)
+func (c *Canary) GetMetricInterval() string {
+	return MetricInterval
 }

--- a/pkg/apis/flagger/v1alpha3/types.go
+++ b/pkg/apis/flagger/v1alpha3/types.go
@@ -127,9 +127,11 @@ type CanaryAnalysis struct {
 
 // CanaryMetric holds the reference to Istio metrics used for canary analysis
 type CanaryMetric struct {
-	Name      string `json:"name"`
-	Interval  string `json:"interval"`
-	Threshold int    `json:"threshold"`
+	Name      string  `json:"name"`
+	Interval  string  `json:"interval"`
+	Threshold float64 `json:"threshold"`
+	// +optional
+	Query string `json:"query,omitempty"`
 }
 
 // CanaryWebhook holds the reference to external checks used for canary analysis

--- a/pkg/controller/observer.go
+++ b/pkg/controller/observer.go
@@ -80,8 +80,8 @@ func (c *CanaryObserver) GetScalar(query string) (float64, error) {
 		return 100, nil
 	}
 
-	query = strings.Replace(query, "\n","",-1)
-	query = strings.Replace(query, " ","",-1)
+	query = strings.Replace(query, "\n", "", -1)
+	query = strings.Replace(query, " ", "", -1)
 
 	var value *float64
 	result, err := c.queryMetric(query)

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -405,6 +405,10 @@ func (c *Controller) analyseCanary(r *flaggerv1.Canary) bool {
 
 	// run metrics checks
 	for _, metric := range r.Spec.CanaryAnalysis.Metrics {
+		if metric.Interval == "" {
+			metric.Interval = r.GetMetricInterval()
+		}
+
 		if metric.Name == "istio_requests_total" {
 			val, err := c.observer.GetDeploymentCounter(r.Spec.TargetRef.Name, r.Namespace, metric.Name, metric.Interval)
 			if err != nil {

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -436,6 +436,24 @@ func (c *Controller) analyseCanary(r *flaggerv1.Canary) bool {
 				return false
 			}
 		}
+
+		if metric.Query != "" {
+			val, err := c.observer.GetScalar(metric.Query)
+			if err != nil {
+				if strings.Contains(err.Error(), "no values found") {
+					c.recordEventWarningf(r, "Halt advancement no values found for metric %s probably %s.%s is not receiving traffic",
+						metric.Name, r.Spec.TargetRef.Name, r.Namespace)
+				} else {
+					c.recordEventErrorf(r, "Metrics server %s query failed: %v", c.observer.metricsServer, err)
+				}
+				return false
+			}
+			if val > float64(metric.Threshold) {
+				c.recordEventWarningf(r, "Halt %s.%s advancement %s %.2f > %v",
+					r.Name, r.Namespace, metric.Name, val, metric.Threshold)
+				return false
+			}
+		}
 	}
 
 	return true

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -45,6 +45,30 @@ spec:
     - name: istio_request_duration_seconds_bucket
       threshold: 500
       interval: 30s
+    - name: "404s percentage"
+      threshold: 5
+      interval: 1m
+      query: |
+        100 - sum(
+            rate(
+                istio_requests_total{
+                  reporter="destination",
+                  destination_workload_namespace=~"test",
+                  destination_workload=~"podinfo",
+                  response_code!="404"
+                }[1m]
+            )
+        )
+        /
+        sum(
+            rate(
+                istio_requests_total{
+                  reporter="destination",
+                  destination_workload_namespace=~"test",
+                  destination_workload=~"podinfo"
+                }[1m]
+            )
+        ) * 100
     webhooks:
       - name: load-test
         url: http://flagger-loadtester.test/


### PR DESCRIPTION
This PR adds a `query` field to the Canary CRD and implements custom metric checks. Flagger will run the promql query,  converts the result to `float64` and compares it with the metric threshold. This allows for arbitrary Prometheus scalar queries to be used in the analysis process.

Example:

```yaml
  canaryAnalysis:
    threshold: 10
    maxWeight: 50
    stepWeight: 5
    metrics:
    - name: "404s percentage"
      threshold: 5
      interval: 1m
      query: |
        100 - sum(
            rate(
                istio_requests_total{
                  reporter="destination",
                  destination_workload_namespace="test",
                  destination_workload="podinfo",
                  response_code!="404"
                }[1m]
            )
        )
        /
        sum(
            rate(
                istio_requests_total{
                  reporter="destination",
                  destination_workload_namespace="test",
                  destination_workload="podinfo"
                }[1m]
            )
        ) * 100
```

The above config validates the canary by checking if the HTTP 404 req/sec percentage is below 5 percent. If the 404s rate reaches the 5% threshold the canary fails. 

Failed check event:

```
Halt podinfo.test advancement 404s percentage 52.84 > 5
```

Fix: #59 
Fix: #8 