### PR TITLE
Fixed namepace typo in the repo

### DIFF
--- a/docs/gitbook/how-it-works.md
+++ b/docs/gitbook/how-it-works.md
@@ -509,7 +509,7 @@ Or by using Helm:
 helm repo add flagger https://flagger.app
 
 helm upgrade -i flagger-loadtester flagger/loadtester \
---namepace=test \
+--namespace=test \
 --set cmd.logOutput=true \
 --set cmd.timeout=1h
 ```

--- a/docs/gitbook/install/flagger-install-on-kubernetes.md
+++ b/docs/gitbook/install/flagger-install-on-kubernetes.md
@@ -125,7 +125,7 @@ Deploy the load test runner with Helm:
 
 ```bash
 helm upgrade -i flagger-loadtester flagger/loadtester \
---namepace=test \
+--namespace=test \
 --set cmd.logOutput=true \
 --set cmd.timeout=1h
 ```

--- a/docs/gitbook/tutorials/canary-helm-gitops.md
+++ b/docs/gitbook/tutorials/canary-helm-gitops.md
@@ -115,7 +115,7 @@ First let's install a load testing service that will generate traffic during ana
 
 ```bash
 helm upgrade -i flagger-loadtester flagger/loadtester \
---namepace=test
+--namespace=test
 ```
 
 Enable the load tester and deploy a new `frontend` version:

--- a/pkg/controller/webhook.go
+++ b/pkg/controller/webhook.go
@@ -15,10 +15,10 @@ import (
 
 // CallWebhook does a HTTP POST to an external service and
 // returns an error if the response status code is non-2xx
-func CallWebhook(name string, namepace string, w flaggerv1.CanaryWebhook) error {
+func CallWebhook(name string, namespace string, w flaggerv1.CanaryWebhook) error {
 	payload := flaggerv1.CanaryWebhookPayload{
 		Name:      name,
-		Namespace: namepace,
+		Namespace: namespace,
 	}
 
 	if w.Metadata != nil {


### PR DESCRIPTION
was going through the documentation and found a typo we have in the helm command

