### PR TITLE
add enable option for understandability

### DIFF
--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           - ./flagger
           - -log-level=info
           - -metrics-server={{ .Values.metricsServer }}
-          {{- if .Values.slack.url }}
+          {{- if .Values.slack.enable }}
           - -slack-url={{ .Values.slack.url }}
           - -slack-user={{ .Values.slack.user }}
           - -slack-channel={{ .Values.slack.channel }}

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -8,6 +8,7 @@ image:
 metricsServer: "http://prometheus.istio-system.svc.cluster.local:9090"
 
 slack:
+  enable: false
   user: flagger
   channel:
   # incoming webhook https://api.slack.com/incoming-webhooks


### PR DESCRIPTION
Dear all,

When first seen a values.yaml in charts/flagger, I didn't know how to disable slack.(but slack was disable by default because url is empty)

This patch makes easy to understand that slack is enable or disable.