### PR TITLE
Add namespace flag

### DIFF
--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
           - ./flagger
           - -log-level=info
           - -metrics-server={{ .Values.metricsServer }}
+          {{- if .Values.namespace }}
+          - -namespace={{ .Values.namespace }}
+          {{- end }}
           {{- if .Values.slack.url }}
           - -slack-url={{ .Values.slack.url }}
           - -slack-user={{ .Values.slack.user }}

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -7,6 +7,9 @@ image:
 
 metricsServer: "http://prometheus.istio-system.svc.cluster.local:9090"
 
+# Namespace that flagger will watch for Canary objects
+namespace: ""
+
 slack:
   user: flagger
   channel:


### PR DESCRIPTION
- introduce the namespace flag for flagger to watch a single namespace for Canary Objects

Fix: #38 

@stefanprodan 