### PR TITLE
Add CORS policy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ spec:
           x-envoy-upstream-rq-timeout-ms: "15000"
           x-envoy-max-retries: "10"
           x-envoy-retry-on: "gateway-error,connect-failure,refused-stream"
+    # cross-origin resource sharing policy (optional)
+    corsPolicy:
+      allowOrigin:
+        - example.com
   # promote the canary without analysing it (default false)
   skipAnalysis: false
   # define the canary analysis timing and KPIs

--- a/docs/gitbook/how-it-works.md
+++ b/docs/gitbook/how-it-works.md
@@ -132,6 +132,16 @@ metadata:
           x-envoy-upstream-rq-timeout-ms: "15000"
           x-envoy-max-retries: "10"
           x-envoy-retry-on: "gateway-error,connect-failure,refused-stream"
+    # cross-origin resource sharing policy (optional)
+    corsPolicy:
+      allowOrigin:
+        - example.com
+      allowMethods:
+        - GET
+      allowCredentials: false
+      allowHeaders:
+        - x-some-header
+      maxAge: 24h
     # retry policy when a HTTP request fails (optional)
     retries:
       attempts: 3
@@ -165,6 +175,14 @@ spec:
       x-envoy-max-retries: "10"
       x-envoy-retry-on: gateway-error,connect-failure,refused-stream
       x-envoy-upstream-rq-timeout-ms: "15000"
+    corsPolicy:
+      allowHeaders:
+      - x-some-header
+      allowMethods:
+      - GET
+      allowOrigin:
+      - example.com
+      maxAge: 24h
     match:
     - uri:
         prefix: /

--- a/docs/gitbook/how-it-works.md
+++ b/docs/gitbook/how-it-works.md
@@ -109,6 +109,7 @@ kind: Canary
 metadata:
   name: frontend
   namespace: test
+spec:
   service:
     # container port
     port: 9898

--- a/pkg/apis/flagger/v1alpha3/types.go
+++ b/pkg/apis/flagger/v1alpha3/types.go
@@ -109,14 +109,15 @@ type CanaryStatus struct {
 // CanaryService is used to create ClusterIP services
 // and Istio Virtual Service
 type CanaryService struct {
-	Port     int32                            `json:"port"`
-	Gateways []string                         `json:"gateways"`
-	Hosts    []string                         `json:"hosts"`
-	Match    []istiov1alpha3.HTTPMatchRequest `json:"match,omitempty"`
-	Rewrite  *istiov1alpha3.HTTPRewrite       `json:"rewrite,omitempty"`
-	Timeout  string                           `json:"timeout,omitempty"`
-	Retries  *istiov1alpha3.HTTPRetry         `json:"retries,omitempty"`
-	Headers  *istiov1alpha3.Headers           `json:"headers,omitempty"`
+	Port       int32                            `json:"port"`
+	Gateways   []string                         `json:"gateways"`
+	Hosts      []string                         `json:"hosts"`
+	Match      []istiov1alpha3.HTTPMatchRequest `json:"match,omitempty"`
+	Rewrite    *istiov1alpha3.HTTPRewrite       `json:"rewrite,omitempty"`
+	Timeout    string                           `json:"timeout,omitempty"`
+	Retries    *istiov1alpha3.HTTPRetry         `json:"retries,omitempty"`
+	Headers    *istiov1alpha3.Headers           `json:"headers,omitempty"`
+	CorsPolicy *istiov1alpha3.CorsPolicy        `json:"corsPolicy,omitempty"`
 }
 
 // CanaryAnalysis is used to describe how the analysis should be done

--- a/pkg/apis/flagger/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/flagger/v1alpha3/zz_generated.deepcopy.go
@@ -166,6 +166,11 @@ func (in *CanaryService) DeepCopyInto(out *CanaryService) {
 		*out = new(istiov1alpha3.Headers)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.CorsPolicy != nil {
+		in, out := &in.CorsPolicy, &out.CorsPolicy
+		*out = new(istiov1alpha3.CorsPolicy)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/apis/istio/v1alpha3/virtual_service.go
+++ b/pkg/apis/istio/v1alpha3/virtual_service.go
@@ -328,7 +328,7 @@ type HTTPRoute struct {
 	// Cross-Origin Resource Sharing policy (CORS). Refer to
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
 	// for further details about cross origin resource sharing.
-	CorsPolicy *CorsPolicy `json:"CorsPolicy,omitempty"`
+	CorsPolicy *CorsPolicy `json:"corsPolicy,omitempty"`
 
 	// Additional HTTP headers to add before forwarding a request to the
 	// destination service.

--- a/pkg/router/istio.go
+++ b/pkg/router/istio.go
@@ -85,6 +85,7 @@ func (ir *IstioRouter) Sync(canary *flaggerv1.Canary) error {
 				Rewrite:       canary.Spec.Service.Rewrite,
 				Timeout:       canary.Spec.Service.Timeout,
 				Retries:       canary.Spec.Service.Retries,
+				CorsPolicy:    canary.Spec.Service.CorsPolicy,
 				AppendHeaders: addHeaders(canary),
 				Route:         route,
 			},
@@ -201,6 +202,7 @@ func (ir *IstioRouter) SetRoutes(
 			Rewrite:       canary.Spec.Service.Rewrite,
 			Timeout:       canary.Spec.Service.Timeout,
 			Retries:       canary.Spec.Service.Retries,
+			CorsPolicy:    canary.Spec.Service.CorsPolicy,
 			AppendHeaders: addHeaders(canary),
 			Route: []istiov1alpha3.DestinationWeight{
 				{

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -65,6 +65,12 @@ func newMockCanary() *v1alpha3.Canary {
 						},
 					},
 				},
+				CorsPolicy: &istiov1alpha3.CorsPolicy{
+					AllowMethods: []string{
+						"GET",
+						"POST",
+					},
+				},
 			}, CanaryAnalysis: v1alpha3.CanaryAnalysis{
 				Threshold:  10,
 				StepWeight: 10,

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -33,10 +33,12 @@ spec:
   progressDeadlineSeconds: 60
   service:
     port: 9898
-    appendHeaders:
-      x-envoy-upstream-rq-timeout-ms: "15000"
-      x-envoy-max-retries: "10"
-      x-envoy-retry-on: "gateway-error,connect-failure,refused-stream"
+    headers:
+      request:
+        add:
+          x-envoy-upstream-rq-timeout-ms: "15000"
+          x-envoy-max-retries: "10"
+          x-envoy-retry-on: "gateway-error,connect-failure,refused-stream"
   canaryAnalysis:
     interval: 15s
     threshold: 15


### PR DESCRIPTION
This PR allows cross-origin resource sharing policy to be specified in the Canary service spec.

```yaml
apiVersion: flagger.app/v1alpha3
kind: Canary
spec:
  service:
    port: 9898
    corsPolicy:
      allowOrigin:
        - example.com
      allowMethods:
        - GET
      allowCredentials: false
      allowHeaders:
        - x-some-header
      maxAge: 24h
```

Fix: #58 