### PR TITLE
Fix A/B Testing HTTP URI match conditions

### DIFF
--- a/artifacts/ab-testing/canary.yaml
+++ b/artifacts/ab-testing/canary.yaml
@@ -40,7 +40,7 @@ spec:
             regex: "^(?!.*Chrome)(?=.*\bSafari\b).*$"
       - headers:
           cookie:
-            regex: "^(.*?;)?(user=test)(;.*)?$"
+            regex: "^(.*?;)?(type=insider)(;.*)?$"
     metrics:
     - name: istio_requests_total
       # minimum req success rate (non 5xx responses)
@@ -58,4 +58,4 @@ spec:
         url: http://flagger-loadtester.test/
         timeout: 5s
         metadata:
-          cmd: "hey -z 1m -q 10 -c 2 http://podinfo.test:9898/"
+          cmd: "hey -z 1m -q 10 -c 2 -H 'Cookie: type=insider' http://podinfo.test:9898/"

--- a/docs/gitbook/how-it-works.md
+++ b/docs/gitbook/how-it-works.md
@@ -347,7 +347,7 @@ You can enable A/B testing by specifying the HTTP match conditions and the numbe
     match:
       - headers:
           user-agent:
-            regex: "^(?!.*Chrome)(?=.*\bSafari\b).*$"
+            regex: "^(?!.*Chrome).*Safari.*"
       - headers:
           cookie:
             regex: "^(.*?;)?(user=test)(;.*)?$"

--- a/docs/gitbook/usage/ab-testing.md
+++ b/docs/gitbook/usage/ab-testing.md
@@ -93,7 +93,7 @@ spec:
         url: http://flagger-loadtester.test/
         timeout: 5s
         metadata:
-          cmd: "hey -z 1m -q 10 -c 2 http://podinfo.test:9898/"
+          cmd: "hey -z 1m -q 10 -c 2 -H 'Cookie: type=insider' http://podinfo.test:9898/"
 ```
 
 The above configuration will run an analysis for ten minutes targeting Safari users and those that have an insider cookie.

--- a/docs/gitbook/usage/ab-testing.md
+++ b/docs/gitbook/usage/ab-testing.md
@@ -72,7 +72,7 @@ spec:
     match:
       - headers:
           user-agent:
-            regex: "^(?!.*Chrome)(?=.*\bSafari\b).*$"
+            regex: "^(?!.*Chrome).*Safari.*"
       - headers:
           cookie:
             regex: "^(.*?;)?(type=insider)(;.*)?$"


### PR DESCRIPTION
Copy the URI match conditions specified in `service.match` over `canaryAnalysis.match`.